### PR TITLE
Job: Kill

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -16,6 +16,8 @@ const (
 
 	// CodeInvalidJobJSON means a POST body to /jobs was not parseable JSON.
 	CodeInvalidJobJSON = "JPRS"
+	// CodeInvalidJobForm means that a POST body did not contain form-encoded data.
+	CodeInvalidJobForm = "JFRM"
 	// CodeMissingCommand means a job is missing a "cmd" element.
 	CodeMissingCommand = "JCMD"
 	// CodeInvalidResultSource means a job has an invalid result source.

--- a/codes.go
+++ b/codes.go
@@ -1,6 +1,9 @@
 package main
 
 const (
+	// CodeWTF is returned when an invariant turns out not to be true.
+	CodeWTF = "WTF"
+
 	// CodeCredentialsMissing means a request that was required to be authenticated had no auth data.
 	CodeCredentialsMissing = "ANONE"
 	// CodeCredentialsIncorrect means auth data on a request was present, but incorrect.
@@ -23,4 +26,8 @@ const (
 	CodeEnqueueFailure = "JQUEUE"
 	// CodeListFailure means that a query for jobs could not be performed by storage engine.
 	CodeListFailure = "JLIST"
+	// CodeJobUpdateFailure means that an update to an existing job was unable to be performed.
+	CodeJobUpdateFailure = "JUPD"
+	// CodeJobNotFound means that an action was attempted on a job that doesn't exist.
+	CodeJobNotFound = "JNF"
 )

--- a/codes.go
+++ b/codes.go
@@ -26,6 +26,8 @@ const (
 	CodeEnqueueFailure = "JQUEUE"
 	// CodeListFailure means that a query for jobs could not be performed by storage engine.
 	CodeListFailure = "JLIST"
+	// CodeJobKillFailure means that a job's container was unable to be killed.
+	CodeJobKillFailure = "JKILL"
 	// CodeJobUpdateFailure means that an update to an existing job was unable to be performed.
 	CodeJobUpdateFailure = "JUPD"
 	// CodeJobNotFound means that an action was attempted on a job that doesn't exist.

--- a/context.go
+++ b/context.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -31,8 +30,6 @@ type Settings struct {
 	DockerKey    string
 	Image        string
 	Poll         int
-	Web          bool
-	Runner       bool
 }
 
 // NewContext loads the active configuration and applies any immediate, global settings like the
@@ -139,15 +136,6 @@ func (c *Context) Load() error {
 
 	if _, err := log.ParseLevel(c.LogLevel); err != nil {
 		return err
-	}
-
-	// If neither web nor runner are explicitly enabled, enable both.
-	if !c.Web && !c.Runner {
-		if os.Getenv("PIPE_WEB") != "" && os.Getenv("PIPE_RUNNER") != "" {
-			return errors.New("You must enable either PIPE_WEB or PIPE_RUNNER!")
-		}
-
-		c.Web, c.Runner = true, true
 	}
 
 	return nil

--- a/context.go
+++ b/context.go
@@ -47,10 +47,17 @@ func NewContext() (*Context, error) {
 	// Summarize the loaded settings.
 
 	log.WithFields(log.Fields{
-		"port":          c.Port,
-		"logging level": c.LogLevel,
-		"mongo URL":     c.MongoURL,
-		"admin account": c.AdminName,
+		"port":               c.Port,
+		"logging level":      c.LogLevel,
+		"mongo URL":          c.MongoURL,
+		"admin account":      c.AdminName,
+		"docker host":        c.DockerHost,
+		"docker TLS enabled": c.DockerTLS,
+		"docker CA cert":     c.DockerCACert,
+		"docker cert":        c.DockerCert,
+		"docker key":         c.DockerKey,
+		"default layer":      c.Image,
+		"polling interval":   c.Poll,
 	}).Info("Initializing with loaded settings.")
 
 	// Configure the logging level.

--- a/context_test.go
+++ b/context_test.go
@@ -22,8 +22,6 @@ func TestLoadFromEnvironment(t *testing.T) {
 	os.Setenv("PIPE_DOCKERCACERT", "/lockbox/ca.pem")
 	os.Setenv("PIPE_DOCKERCERT", "/lockbox/cert.pem")
 	os.Setenv("PIPE_DOCKERKEY", "/lockbox/key.pem")
-	os.Setenv("PIPE_WEB", "true")
-	os.Setenv("PIPE_RUNNER", "true")
 
 	if err := c.Load(); err != nil {
 		t.Errorf("Error loading configuration: %v", err)
@@ -76,14 +74,6 @@ func TestLoadFromEnvironment(t *testing.T) {
 	if c.AdminKey != "12345" {
 		t.Errorf("Unexpected administrator API key: [%s]", c.AdminKey)
 	}
-
-	if !c.Web {
-		t.Error("Expected Web to be enabled.")
-	}
-
-	if !c.Runner {
-		t.Error("Expected Runner to be enabled.")
-	}
 }
 
 func TestDefaultValues(t *testing.T) {
@@ -104,8 +94,6 @@ func TestDefaultValues(t *testing.T) {
 	os.Setenv("DOCKER_TLS_VERIFY", "")
 	os.Setenv("DOCKER_CERT_PATH", "")
 	os.Setenv("PIPE_IMAGE", "")
-	os.Setenv("PIPE_WEB", "")
-	os.Setenv("PIPE_RUNNER", "")
 
 	u, err := user.Current()
 	if err != nil {
@@ -155,47 +143,6 @@ func TestDefaultValues(t *testing.T) {
 
 	if c.Image != "cloudpipe/runner-py2" {
 		t.Errorf("Unexpected default image: [%s]", c.Image)
-	}
-
-	if !c.Web {
-		t.Error("Expected Web to be enabled.")
-	}
-	if !c.Runner {
-		t.Error("Expected Runner to be enabled.")
-	}
-}
-
-func TestOnlyWeb(t *testing.T) {
-	os.Setenv("PIPE_WEB", "true")
-	os.Setenv("PIPE_RUNNER", "")
-
-	c := Context{}
-	if err := c.Load(); err != nil {
-		t.Errorf("Error loading configuration: %v", err)
-	}
-
-	if !c.Web {
-		t.Error("Expected Web to be enabled.")
-	}
-	if c.Runner {
-		t.Error("Expected Runner to be disabled.")
-	}
-}
-
-func TestOnlyRunner(t *testing.T) {
-	os.Setenv("PIPE_WEB", "")
-	os.Setenv("PIPE_RUNNER", "true")
-
-	c := Context{}
-	if err := c.Load(); err != nil {
-		t.Errorf("Error loading configuration: %v", err)
-	}
-
-	if c.Web {
-		t.Error("Expected Web to be disabled.")
-	}
-	if !c.Runner {
-		t.Error("Expected Runner to be enabled.")
 	}
 }
 

--- a/docker.go
+++ b/docker.go
@@ -13,6 +13,7 @@ type Docker interface {
 	WaitContainer(string) (int, error)
 	CopyFromContainer(docker.CopyFromContainerOptions) error
 	RemoveContainer(docker.RemoveContainerOptions) error
+	KillContainer(docker.KillContainerOptions) error
 }
 
 // NullDocker is an embeddable struct that implements the full Docker interface as no-ops, allowing
@@ -46,6 +47,11 @@ func (n NullDocker) CopyFromContainer(docker.CopyFromContainerOptions) error {
 
 // RemoveContainer is a no-op.
 func (n NullDocker) RemoveContainer(docker.RemoveContainerOptions) error {
+	return nil
+}
+
+// KillContainer is a no-op.
+func (n NullDocker) KillContainer(docker.KillContainerOptions) error {
 	return nil
 }
 

--- a/docker.go
+++ b/docker.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	docker "github.com/smashwilson/go-dockerclient"
+)
+
+// Docker enumerates interactions with the Docker client, allowing us to use alternate
+// implementations for testing.
+type Docker interface {
+	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
+	AttachToContainer(docker.AttachToContainerOptions) error
+	StartContainer(string, *docker.HostConfig) error
+	WaitContainer(string) (int, error)
+	CopyFromContainer(docker.CopyFromContainerOptions) error
+	RemoveContainer(docker.RemoveContainerOptions) error
+}
+
+// NullDocker is an embeddable struct that implements the full Docker interface as no-ops, allowing
+// you to only implement the calls that you care about for a specific test.
+type NullDocker struct{}
+
+// CreateContainer is a no-op that always returns nil and no error.
+func (n NullDocker) CreateContainer(docker.CreateContainerOptions) (*docker.Container, error) {
+	return nil, nil
+}
+
+// AttachToContainer is a no-op.
+func (n NullDocker) AttachToContainer(docker.AttachToContainerOptions) error {
+	return nil
+}
+
+// StartContainer is a no-op.
+func (n NullDocker) StartContainer(string, *docker.HostConfig) error {
+	return nil
+}
+
+// WaitContainer is a no-op.
+func (n NullDocker) WaitContainer(string) (int, error) {
+	return 0, nil
+}
+
+// CopyFromContainer is a no-op.
+func (n NullDocker) CopyFromContainer(docker.CopyFromContainerOptions) error {
+	return nil
+}
+
+// RemoveContainer is a no-op.
+func (n NullDocker) RemoveContainer(docker.RemoveContainerOptions) error {
+	return nil
+}
+
+// Ensure that NullDocker adheres to the Docker interface.
+var _ Docker = NullDocker{}

--- a/job.go
+++ b/job.go
@@ -158,8 +158,9 @@ type SubmittedJob struct {
 
 	Collected Collected `json:"collected,omitempty" bson:"collected,omitempty"`
 
-	JID     uint64 `json:"jid" bson:"_id"`
-	Account string `json:"-" bson:"account"`
+	JID           uint64 `json:"jid" bson:"_id"`
+	Account       string `json:"-" bson:"account"`
+	KillRequested bool   `json:"-" bson:"kill_requested"`
 }
 
 // ContainerName derives a name for the Docker container used to execute this job.

--- a/job.go
+++ b/job.go
@@ -437,10 +437,14 @@ func JobKillHandler(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jobs, err := c.ListJobs(JobQuery{
-		JIDs:        []uint64{jid},
-		AccountName: account.Name,
-	})
+	sudo := r.PostFormValue("sudo") == "true"
+
+	query := JobQuery{JIDs: []uint64{jid}}
+	if !sudo {
+		query.AccountName = account.Name
+	}
+
+	jobs, err := c.ListJobs(query)
 	if err != nil {
 		APIError{
 			Code:    CodeListFailure,
@@ -510,11 +514,13 @@ func JobKillHandler(c *Context, w http.ResponseWriter, r *http.Request) {
 		log.WithFields(log.Fields{
 			"jid":     job.JID,
 			"account": account.Name,
+			"sudo":    sudo,
 		}).Info("Running job killed.")
 	} else {
 		log.WithFields(log.Fields{
 			"jid":     job.JID,
 			"account": account.Name,
+			"sudo":    sudo,
 		}).Info("Job kill requested.")
 	}
 

--- a/job_test.go
+++ b/job_test.go
@@ -41,6 +41,11 @@ func (storage *JobStorage) ListJobs(query JobQuery) ([]SubmittedJob, error) {
 	return []SubmittedJob{j0, j1, j2}, nil
 }
 
+func (storage *JobStorage) UpdateJob(job *SubmittedJob) error {
+	storage.Submitted = *job
+	return nil
+}
+
 func TestJobHandlerBadRequest(t *testing.T) {
 	r, err := http.NewRequest("PUT", "https://localhost/v1/jobs", nil)
 	if err != nil {
@@ -329,5 +334,28 @@ func TestSubmittedJobContainerName(t *testing.T) {
 	anonymous := SubmittedJob{JID: 4321}
 	if containerName := anonymous.ContainerName(); containerName != "job_4321_unnamed" {
 		t.Errorf("Expected anonymous name to be [job_4321_unnamed], was [%s]", containerName)
+	}
+}
+
+func TestSubmitJobKill(t *testing.T) {
+	r, err := http.NewRequest("POST", "https://localhost/v1/jobs/kill", strings.NewReader(`{ "jid": 1234 }`))
+	if err != nil {
+		t.Fatalf("Unable to create request: %v", err)
+	}
+	r.SetBasicAuth("admin", "12345")
+	w := httptest.NewRecorder()
+	s := &JobStorage{}
+	c := &Context{
+		Settings: Settings{
+			AdminName: "admin",
+			AdminKey:  "12345",
+		},
+		Storage: s,
+	}
+
+	JobKillHandler(c, w, r)
+
+	if !s.Submitted.KillRequested {
+		t.Error("Expected a job kill to be requested")
 	}
 }

--- a/job_test.go
+++ b/job_test.go
@@ -38,7 +38,19 @@ func (storage *JobStorage) ListJobs(query JobQuery) ([]SubmittedJob, error) {
 		JID: 33,
 	}
 
-	return []SubmittedJob{j0, j1, j2}, nil
+	results := make([]SubmittedJob, 0, 3)
+	for _, job := range []SubmittedJob{j0, j1, j2} {
+		if len(query.JIDs) > 0 {
+			for _, jid := range query.JIDs {
+				if job.JID == jid {
+					results = append(results, job)
+				}
+			}
+		} else {
+			results = append(results, job)
+		}
+	}
+	return results, nil
 }
 
 func (storage *JobStorage) UpdateJob(job *SubmittedJob) error {
@@ -338,7 +350,7 @@ func TestSubmittedJobContainerName(t *testing.T) {
 }
 
 func TestSubmitJobKill(t *testing.T) {
-	r, err := http.NewRequest("POST", "https://localhost/v1/jobs/kill", strings.NewReader(`{ "jid": 1234 }`))
+	r, err := http.NewRequest("POST", "https://localhost/v1/jobs/kill", strings.NewReader(`{ "jid": 11 }`))
 	if err != nil {
 		t.Fatalf("Unable to create request: %v", err)
 	}

--- a/job_test.go
+++ b/job_test.go
@@ -350,7 +350,8 @@ func TestSubmittedJobContainerName(t *testing.T) {
 }
 
 func TestSubmitJobKill(t *testing.T) {
-	r, err := http.NewRequest("POST", "https://localhost/v1/jobs/kill", strings.NewReader(`{ "jid": 11 }`))
+	r, err := http.NewRequest("POST", "https://localhost/v1/jobs/kill", strings.NewReader("jid=11"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		t.Fatalf("Unable to create request: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -20,28 +20,19 @@ func main() {
 
 	log.Info("Commence primary ignition.")
 
-	if c.Runner {
-		if c.Web {
-			log.Info("Launching job runner as a goroutine.")
-			go Runner(c)
-		} else {
-			log.Info("Launching job runner in the foreground.")
-			Runner(c)
-		}
-	}
+	log.Info("Launching job runner.")
+	go Runner(c)
 
-	if c.Web {
-		// v1 routes
-		http.HandleFunc("/v1/job", BindContext(c, JobHandler))
-		http.HandleFunc("/v1/job/kill", BindContext(c, JobKillHandler))
-		http.HandleFunc("/v1/job/kill_all", BindContext(c, JobKillAllHandler))
-		http.HandleFunc("/v1/job/queue_stats", BindContext(c, JobQueueStatsHandler))
+	// v1 routes
+	http.HandleFunc("/v1/job", BindContext(c, JobHandler))
+	http.HandleFunc("/v1/job/kill", BindContext(c, JobKillHandler))
+	http.HandleFunc("/v1/job/kill_all", BindContext(c, JobKillAllHandler))
+	http.HandleFunc("/v1/job/queue_stats", BindContext(c, JobQueueStatsHandler))
 
-		log.WithFields(log.Fields{
-			"address": c.ListenAddr(),
-		}).Info("Web API listening.")
-		http.ListenAndServe(c.ListenAddr(), nil)
-	}
+	log.WithFields(log.Fields{
+		"address": c.ListenAddr(),
+	}).Info("Web API listening.")
+	http.ListenAndServe(c.ListenAddr(), nil)
 }
 
 // ContextHandler is an HTTP HandlerFunc that accepts an additional parameter containing the

--- a/main.go
+++ b/main.go
@@ -132,3 +132,8 @@ func (t *StoredTime) UnmarshalJSON(input []byte) error {
 	*t = StoredTime(parsed.UTC().UnixNano())
 	return err
 }
+
+// OKResponse returns the standard "all is well" response.
+func OKResponse(w http.ResponseWriter) {
+	fmt.Fprintf(w, `{"status":"ok"}`)
+}

--- a/runner.go
+++ b/runner.go
@@ -230,8 +230,17 @@ func Execute(c *Context, job *SubmittedJob) {
 
 			// See if a kill was explicitly requested. If so, transition to StatusKilled. Otherwise,
 			// transition to StatusError.
+			killed, err := c.JobKillRequested(job.JID)
+			if err != nil {
+				reportErr("Check the job kill status: ERROR", err)
+				return
+			}
 
-			job.Status = StatusError
+			if killed {
+				job.Status = StatusKilled
+			} else {
+				job.Status = StatusError
+			}
 		}
 
 		// Extract the result from the job.

--- a/script/sample/killjob.py
+++ b/script/sample/killjob.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import multyvac
+import time
+import sys
+
+multyvac.config.set_key(api_key='admin', api_secret_key='12345', api_url='http://docker:8000/v1')
+
+def longtime(seconds):
+    print("Getting started")
+    sys.stdout.flush()
+    for i in xrange(0, seconds):
+        time.sleep(1)
+        print("{} seconds".format(i))
+        sys.stdout.flush()
+
+jid = multyvac.submit(longtime, 30)
+time.sleep(5)
+multyvac.kill(jid)
+time.sleep(1)
+j = multyvac.get(jid)
+print("job = {}, status = {}".format(j, j.status))

--- a/storage.go
+++ b/storage.go
@@ -180,9 +180,9 @@ func (storage *MongoStorage) ListJobs(query JobQuery) ([]SubmittedJob, error) {
 // JobKillRequested returns true if a request has been submitted to kill the job with with provided
 // JID, and false otherwise.
 func (storage *MongoStorage) JobKillRequested(id uint64) (bool, error) {
-	var result bool
+	var result SubmittedJob
 	err := storage.jobs().FindId(id).Select(bson.M{"kill_requested": 1}).One(&result)
-	return result, err
+	return result.KillRequested, err
 }
 
 // ClaimJob atomically searches for the oldest pending SubmittedJob, marks it as StatusProcessing,


### PR DESCRIPTION
This is an implementation of the Job: Kill API call, the first part of #33.

- [x] Basic `JobKillHandler`: locate the requested job, set the kill flag, and return.
- [x] Also kill the running container.
- [x] In the job runner, when the attach call returns, check the job kill flag. If it's true, then a nonzero return status implies `StatusKilled`, not `StatusError`.
- [x] Allow admins to kill other accounts' jobs, but only if a `"sudo": true` setting is provided.