### PR TITLE
Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 certificates/*.pem
 certificates/*.csr
 certificates/*.srl
+certificates/*.password

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# locally-generated development certificates
+certificates/*.pem
+certificates/*.csr
+certificates/*.srl

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Compute on demand in Docker containers.
 
  1. Install [Docker](https://docs.docker.com/installation/mac/) on your platform.
  2. Install [fig](http://www.fig.sh/install.html).
- 3. Run `fig build && fig up -d` to build and launch everything locally.
+ 3. Generate development TLS credentials by running `script/genkeys`.
+ 4. Run `fig build && fig up -d` to build and launch everything locally.
 
 To run the tests, use `script/test`. You can also use `script/mongo` to connect to your local MongoDB
 database.
@@ -26,7 +27,7 @@ Configure the client to connect to yours (default settings from fig shown here):
 
 ```
 >>> import multyvac
->>> api_url = 'http://{}/v1'.format(<your_ip_endpoint>) 
+>>> api_url = 'http://{}/v1'.format(<your_ip_endpoint>)
 >>> multyvac.config.set_key(api_key='admin',
 ...                         api_secret_key='12345',
 ...                         api_url=api_url)

--- a/api_auth.go
+++ b/api_auth.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// AuthDiscoverHandler returns a JSON document describing the currently configured authentication
+// service.
+func AuthDiscoverHandler(c *Context, w http.ResponseWriter, r *http.Request) {
+	type response struct {
+		Address string `json:"address"`
+		Style   string `json:"style"`
+	}
+
+	resp := response{
+		Address: c.Settings.AuthService,
+		Style:   "local",
+	}
+
+	json.NewEncoder(w).Encode(resp)
+}

--- a/api_auth.go
+++ b/api_auth.go
@@ -15,7 +15,7 @@ func AuthDiscoverHandler(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	resp := response{
 		Address: c.Settings.AuthService,
-		Style:   "local",
+		Style:   c.AuthService.Style(),
 	}
 
 	json.NewEncoder(w).Encode(resp)

--- a/api_auth_test.go
+++ b/api_auth_test.go
@@ -49,7 +49,8 @@ func TestDiscoverRemoteAuthService(t *testing.T) {
 	c := &Context{
 		Settings: Settings{AuthService: "https://somewhere.com/"},
 		AuthService: RemoteAuthService{
-			ValidateURL: "https://somewhere.com/validate",
+			ValidateURL:   "https://somewhere.com/validate",
+			ReportedStyle: "cheese",
 		},
 	}
 
@@ -71,7 +72,7 @@ func TestDiscoverRemoteAuthService(t *testing.T) {
 	if response.Address != "https://somewhere.com/" {
 		t.Errorf("Unexpected auth service address: %s", response.Address)
 	}
-	if response.Style != "local" {
+	if response.Style != "cheese" {
 		t.Errorf("Unexpected auth service style: %s", response.Style)
 	}
 }

--- a/api_auth_test.go
+++ b/api_auth_test.go
@@ -7,7 +7,40 @@ import (
 	"testing"
 )
 
-func TestDiscoverAuthService(t *testing.T) {
+func TestDiscoverNullAuthService(t *testing.T) {
+	r, err := http.NewRequest("GET", "https://localhost/v1/auth_service", nil)
+	if err != nil {
+		t.Fatalf("Unable to create request: %v", err)
+	}
+	w := httptest.NewRecorder()
+	c := &Context{
+		AuthService: NullAuthService{},
+	}
+
+	AuthDiscoverHandler(c, w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Unexpected HTTP status: [%d]", w.Code)
+	}
+
+	var response struct {
+		Address string `json:"address"`
+		Style   string `json:"style"`
+	}
+	out := w.Body.Bytes()
+	if err := json.Unmarshal(out, &response); err != nil {
+		t.Fatalf("Unable to parse response body as JSON: [%s]", string(out))
+	}
+
+	if response.Address != "" {
+		t.Errorf("Unexpected auth service address: %s", response.Address)
+	}
+	if response.Style != "null" {
+		t.Errorf("Unexpected auth service style: %s", response.Style)
+	}
+}
+
+func TestDiscoverRemoteAuthService(t *testing.T) {
 	r, err := http.NewRequest("GET", "https://localhost/v1/auth_service", nil)
 	if err != nil {
 		t.Fatalf("Unable to create request: %v", err)
@@ -15,6 +48,9 @@ func TestDiscoverAuthService(t *testing.T) {
 	w := httptest.NewRecorder()
 	c := &Context{
 		Settings: Settings{AuthService: "https://somewhere.com/"},
+		AuthService: RemoteAuthService{
+			ValidateURL: "https://somewhere.com/validate",
+		},
 	}
 
 	AuthDiscoverHandler(c, w, r)

--- a/api_auth_test.go
+++ b/api_auth_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDiscoverAuthService(t *testing.T) {
+	r, err := http.NewRequest("GET", "https://localhost/v1/auth_service", nil)
+	if err != nil {
+		t.Fatalf("Unable to create request: %v", err)
+	}
+	w := httptest.NewRecorder()
+	c := &Context{
+		Settings: Settings{AuthService: "https://somewhere.com/"},
+	}
+
+	AuthDiscoverHandler(c, w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Unexpected HTTP status: [%d]", w.Code)
+	}
+
+	var response struct {
+		Address string `json:"address"`
+		Style   string `json:"style"`
+	}
+	out := w.Body.Bytes()
+	if err := json.Unmarshal(out, &response); err != nil {
+		t.Fatalf("Unable to parse response body as JSON: [%s]", string(out))
+	}
+
+	if response.Address != "https://somewhere.com/" {
+		t.Errorf("Unexpected auth service address: %s", response.Address)
+	}
+	if response.Style != "local" {
+		t.Errorf("Unexpected auth service style: %s", response.Style)
+	}
+}

--- a/auth_service.go
+++ b/auth_service.go
@@ -13,7 +13,7 @@ import (
 // AuthService describes the required and optional services that may be supplied by an authentication
 // backend for cloudpipe.
 type AuthService interface {
-	Validate(username, token string) (bool, error)
+	Validate(accountName, apiKey string) (bool, error)
 }
 
 // ConnectToAuthService initializes an appropriate AuthService implementation based on a (possibly
@@ -46,11 +46,11 @@ type RemoteAuthService struct {
 }
 
 // Validate sends a request to the configured authentication service to determine whether or not
-// a username-token pair is valid.
-func (service RemoteAuthService) Validate(username, token string) (bool, error) {
+// an API key is valid for an account.
+func (service RemoteAuthService) Validate(accountName, apiKey string) (bool, error) {
 	v := url.Values{}
-	v.Set("username", username)
-	v.Set("token", token)
+	v.Set("accountName", accountName)
+	v.Set("apiKey", apiKey)
 	resp, err := service.HTTPS.Get(service.ValidateURL + "?" + v.Encode())
 	if err != nil {
 		return false, err
@@ -69,7 +69,7 @@ func (service RemoteAuthService) Validate(username, token string) (bool, error) 
 		log.WithFields(log.Fields{
 			"status": resp.Status,
 			"body":   string(body),
-		}).Error("The authentication service did something unexpected.")
+		}).Error("The authentication service returned an unexpected response.")
 		return false, fmt.Errorf("unexpected HTTP status %d from auth service", resp.StatusCode)
 	}
 }
@@ -79,8 +79,8 @@ func (service RemoteAuthService) Validate(username, token string) (bool, error) 
 // test cases.
 type NullAuthService struct{}
 
-// Validate rejects all username-token pairs.
-func (service NullAuthService) Validate(username, token string) (bool, error) {
+// Validate rejects all account-API key pairs.
+func (service NullAuthService) Validate(accountName, apiKey string) (bool, error) {
 	return false, nil
 }
 

--- a/auth_service.go
+++ b/auth_service.go
@@ -19,7 +19,7 @@ func ConnectToAuthService(address string) (AuthService, error) {
 		return NullAuthService{}, nil
 	}
 
-	if !strings.HasPrefix(address, "https") {
+	if !strings.HasPrefix(address, "https://") {
 		log.WithFields(log.Fields{
 			"address": address,
 		}).Warn("Non-HTTPS address in use for authentication. Bad! Bad! Bad!")
@@ -36,6 +36,7 @@ type RemoteAuthService struct {
 // Validate sends a request to the configured authentication service to determine whether or not
 // a username-token pair is valid.
 func (service RemoteAuthService) Validate(username, token string) (bool, error) {
+
 	return false, nil
 }
 

--- a/auth_service.go
+++ b/auth_service.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// AuthService describes the required and optional services that may be supplied by an authentication
+// backend for cloudpipe.
+type AuthService interface {
+	Validate(username, token string) (bool, error)
+}
+
+// ConnectToAuthService initializes an appropriate AuthService implementation based on a (possibly
+// omitted) service address.
+func ConnectToAuthService(address string) (AuthService, error) {
+	if address == "" {
+		return NullAuthService{}, nil
+	}
+
+	if !strings.HasPrefix(address, "https") {
+		log.WithFields(log.Fields{
+			"address": address,
+		}).Warn("Non-HTTPS address in use for authentication. Bad! Bad! Bad!")
+	}
+
+	return RemoteAuthService{ValidateURL: address}, nil
+}
+
+// RemoteAuthService is an auth service that's implemented by calls to an HTTPS remote API.
+type RemoteAuthService struct {
+	ValidateURL string
+}
+
+// Validate sends a request to the configured authentication service to determine whether or not
+// a username-token pair is valid.
+func (service RemoteAuthService) Validate(username, token string) (bool, error) {
+	return false, nil
+}
+
+// NullAuthService is an AuthService implementation that refuses all users and provides no optional
+// capabilities. It's used as a default if no AuthService is provided and is useful to embed in
+// test cases.
+type NullAuthService struct{}
+
+// Validate rejects all username-token pairs.
+func (service NullAuthService) Validate(username, token string) (bool, error) {
+	return false, nil
+}
+
+// Ensure that NullAuthService adheres to the AuthService interface.
+
+var _ AuthService = NullAuthService{}

--- a/auth_service.go
+++ b/auth_service.go
@@ -18,9 +18,9 @@ type AuthService interface {
 
 // ConnectToAuthService initializes an appropriate AuthService implementation based on a (possibly
 // omitted) service address.
-func ConnectToAuthService(c *Context, address string) (AuthService, error) {
+func ConnectToAuthService(c *Context, address string) AuthService {
 	if address == "" {
-		return NullAuthService{}, nil
+		return NullAuthService{}
 	}
 
 	if !strings.HasPrefix(address, "https://") {
@@ -36,7 +36,7 @@ func ConnectToAuthService(c *Context, address string) (AuthService, error) {
 	return RemoteAuthService{
 		HTTPS:       c.HTTPS,
 		ValidateURL: address + "validate",
-	}, nil
+	}
 }
 
 // RemoteAuthService is an auth service that's implemented by calls to an HTTPS remote API.

--- a/auth_service.go
+++ b/auth_service.go
@@ -13,7 +13,11 @@ import (
 // AuthService describes the required and optional services that may be supplied by an authentication
 // backend for cloudpipe.
 type AuthService interface {
+	// Validate determines whether or not an API key is valid for a specific, named account.
 	Validate(accountName, apiKey string) (bool, error)
+
+	// Style provides a hint to the UI to indicate what other calls may be valid against this service.
+	Style() string
 }
 
 // ConnectToAuthService initializes an appropriate AuthService implementation based on a (possibly
@@ -74,6 +78,12 @@ func (service RemoteAuthService) Validate(accountName, apiKey string) (bool, err
 	}
 }
 
+// Style provides a hint to external API consumers about other calls and capabilities that this
+// authentication service may implement.
+func (service RemoteAuthService) Style() string {
+	return "local"
+}
+
 // NullAuthService is an AuthService implementation that refuses all users and provides no optional
 // capabilities. It's used as a default if no AuthService is provided and is useful to embed in
 // test cases.
@@ -82,6 +92,11 @@ type NullAuthService struct{}
 // Validate rejects all account-API key pairs.
 func (service NullAuthService) Validate(accountName, apiKey string) (bool, error) {
 	return false, nil
+}
+
+// Style informs any API consumers that no other authentication capabilities are present.
+func (service NullAuthService) Style() string {
+	return "null"
 }
 
 // Ensure that NullAuthService adheres to the AuthService interface.

--- a/auth_service_test.go
+++ b/auth_service_test.go
@@ -53,12 +53,12 @@ func TestSuccessfulRemoteAuth(t *testing.T) {
 			t.Errorf("Unexpected error parsing form: %v", err)
 		}
 
-		if username := r.FormValue("username"); username != "someuser" {
-			t.Errorf("Unexpected username: [%s]", username)
+		if username := r.FormValue("accountName"); username != "someuser" {
+			t.Errorf("Unexpected account name: [%s]", username)
 		}
 
-		if token := r.FormValue("token"); token != "1234567" {
-			t.Errorf("Unexpected token: [%s]", token)
+		if token := r.FormValue("apiKey"); token != "1234567" {
+			t.Errorf("Unexpected API key: [%s]", token)
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/auth_service_test.go
+++ b/auth_service_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	mux    *http.ServeMux
+	server *httptest.Server
+)
+
+func authSetup() {
+	mux = http.NewServeMux()
+	server = httptest.NewServer(mux)
+}
+
+func authTeardown() {
+	server.Close()
+}
+
+func TestDefaultToNullService(t *testing.T) {
+	service, err := ConnectToAuthService("")
+	if err != nil {
+		t.Fatalf("Unexpect error connecting to auth service: %v", err)
+	}
+
+	if _, ok := service.(NullAuthService); !ok {
+		t.Errorf("Expected %#v to be a NullAuthService", service)
+	}
+}
+
+func TestCreateRemoteService(t *testing.T) {
+	authSetup()
+	defer authTeardown()
+
+	service, err := ConnectToAuthService(server.URL)
+	if err != nil {
+		t.Fatalf("Unexpect error connecting to auth service: %v", err)
+	}
+
+	if _, ok := service.(RemoteAuthService); !ok {
+		t.Errorf("Expected %#v to be a RemoteAuthService", service)
+	}
+}

--- a/auth_service_test.go
+++ b/auth_service_test.go
@@ -21,11 +21,7 @@ func authTeardown() {
 }
 
 func TestDefaultToNullService(t *testing.T) {
-	service, err := ConnectToAuthService(&Context{}, "")
-	if err != nil {
-		t.Fatalf("Unexpect error connecting to auth service: %v", err)
-	}
-
+	service := ConnectToAuthService(&Context{}, "")
 	if _, ok := service.(NullAuthService); !ok {
 		t.Errorf("Expected %#v to be a NullAuthService", service)
 	}
@@ -35,11 +31,7 @@ func TestCreateRemoteService(t *testing.T) {
 	authSetup()
 	defer authTeardown()
 
-	service, err := ConnectToAuthService(&Context{}, server.URL)
-	if err != nil {
-		t.Fatalf("Unexpect error connecting to auth service: %v", err)
-	}
-
+	service := ConnectToAuthService(&Context{}, server.URL)
 	if _, ok := service.(RemoteAuthService); !ok {
 		t.Errorf("Expected %#v to be a RemoteAuthService", service)
 	}
@@ -73,11 +65,7 @@ func TestSuccessfulRemoteAuth(t *testing.T) {
 	})
 
 	c := &Context{HTTPS: http.DefaultClient}
-
-	service, err := ConnectToAuthService(c, server.URL)
-	if err != nil {
-		t.Fatalf("Unexpect error connecting to auth service: %v", err)
-	}
+	service := ConnectToAuthService(c, server.URL)
 
 	ok, err := service.Validate("someuser", "1234567")
 	if err != nil {
@@ -104,11 +92,7 @@ func TestUnsuccessfulRemoteAuth(t *testing.T) {
 	})
 
 	c := &Context{HTTPS: http.DefaultClient}
-
-	service, err := ConnectToAuthService(c, server.URL)
-	if err != nil {
-		t.Fatalf("Unexpect error connecting to auth service: %v", err)
-	}
+	service := ConnectToAuthService(c, server.URL)
 
 	ok, err := service.Validate("someuser", "1234567")
 	if err != nil {

--- a/auth_service_test.go
+++ b/auth_service_test.go
@@ -21,7 +21,7 @@ func authTeardown() {
 }
 
 func TestDefaultToNullService(t *testing.T) {
-	service, err := ConnectToAuthService("")
+	service, err := ConnectToAuthService(&Context{}, "")
 	if err != nil {
 		t.Fatalf("Unexpect error connecting to auth service: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestCreateRemoteService(t *testing.T) {
 	authSetup()
 	defer authTeardown()
 
-	service, err := ConnectToAuthService(server.URL)
+	service, err := ConnectToAuthService(&Context{}, server.URL)
 	if err != nil {
 		t.Fatalf("Unexpect error connecting to auth service: %v", err)
 	}
@@ -72,7 +72,9 @@ func TestSuccessfulRemoteAuth(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	service, err := ConnectToAuthService(server.URL)
+	c := &Context{HTTPS: http.DefaultClient}
+
+	service, err := ConnectToAuthService(c, server.URL)
 	if err != nil {
 		t.Fatalf("Unexpect error connecting to auth service: %v", err)
 	}
@@ -101,7 +103,9 @@ func TestUnsuccessfulRemoteAuth(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	service, err := ConnectToAuthService(server.URL)
+	c := &Context{HTTPS: http.DefaultClient}
+
+	service, err := ConnectToAuthService(c, server.URL)
 	if err != nil {
 		t.Fatalf("Unexpect error connecting to auth service: %v", err)
 	}

--- a/auth_service_test.go
+++ b/auth_service_test.go
@@ -44,3 +44,78 @@ func TestCreateRemoteService(t *testing.T) {
 		t.Errorf("Expected %#v to be a RemoteAuthService", service)
 	}
 }
+
+func TestSuccessfulRemoteAuth(t *testing.T) {
+	authSetup()
+	defer authTeardown()
+
+	hit := false
+	mux.HandleFunc("/validate", func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != "GET" {
+			t.Errorf("Expected a GET request, but was [%s]", r.Method)
+		}
+
+		err := r.ParseForm()
+		if err != nil {
+			t.Errorf("Unexpected error parsing form: %v", err)
+		}
+
+		if username := r.FormValue("username"); username != "someuser" {
+			t.Errorf("Unexpected username: [%s]", username)
+		}
+
+		if token := r.FormValue("token"); token != "1234567" {
+			t.Errorf("Unexpected token: [%s]", token)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	service, err := ConnectToAuthService(server.URL)
+	if err != nil {
+		t.Fatalf("Unexpect error connecting to auth service: %v", err)
+	}
+
+	ok, err := service.Validate("someuser", "1234567")
+	if err != nil {
+		t.Fatalf("Unexpected error calling auth service: %v", err)
+	}
+
+	if !hit {
+		t.Errorf("Service never called remote endpoint")
+	}
+
+	if !ok {
+		t.Errorf("Service unexpectedly rejected authentication")
+	}
+}
+
+func TestUnsuccessfulRemoteAuth(t *testing.T) {
+	authSetup()
+	defer authTeardown()
+
+	hit := false
+	mux.HandleFunc("/validate", func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	service, err := ConnectToAuthService(server.URL)
+	if err != nil {
+		t.Fatalf("Unexpect error connecting to auth service: %v", err)
+	}
+
+	ok, err := service.Validate("someuser", "1234567")
+	if err != nil {
+		t.Fatalf("Unexpected error calling auth service: %v", err)
+	}
+
+	if !hit {
+		t.Errorf("Service never called remote endpoint")
+	}
+
+	if ok {
+		t.Errorf("Service unexpectedly accepted authentication")
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -14,6 +14,12 @@ func (service TrustingAuthService) Validate(username, token string) (bool, error
 	return true, nil
 }
 
+// Style yells at you for using this in production somehow, even though it's only defined for
+// tests.
+func (service TrustingAuthService) Style() string {
+	return "what are you, nuts"
+}
+
 func setupAuthRecorder(t *testing.T, username, key string) (*http.Request, *httptest.ResponseRecorder) {
 	r, err := http.NewRequest("GET", "https://localhost/v1/jobs", nil)
 	if err != nil {

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -1,3 +1,5 @@
 # Nice Try
 
 ...but I don't want to even store real *development* TLS credentials in here. Run `script/genkeys` to populate it locally, or check out [the Docker article about configuring TLS support](https://docs.docker.com/articles/https/) if you want to do it yourself. :sparkles:
+
+By default, `script/genkeys` will create a file in this directory called "dev.password" containing the (automatically generated, random) password used by all of the keys and certificates. If you want to use your own instead, repeat it on two lines of a text file with that name.

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -1,0 +1,3 @@
+# Nice Try
+
+...but I don't want to even store real *development* TLS credentials in here. Run `script/genkeys` to populate it locally, or check out [the Docker article about configuring TLS support](https://docs.docker.com/articles/https/) if you want to do it yourself. :sparkles:

--- a/certificates/extclient.cnf
+++ b/certificates/extclient.cnf
@@ -1,0 +1,1 @@
+extendedKeyUsage = clientAuth

--- a/codes.go
+++ b/codes.go
@@ -3,11 +3,15 @@ package main
 const (
 	// CodeWTF is returned when an invariant turns out not to be true.
 	CodeWTF = "WTF"
+	// CodeStorageError means that there was an error interacting with the storage layer.
+	CodeStorageError = "STORE"
 
 	// CodeCredentialsMissing means a request that was required to be authenticated had no auth data.
 	CodeCredentialsMissing = "ANONE"
 	// CodeCredentialsIncorrect means auth data on a request was present, but incorrect.
 	CodeCredentialsIncorrect = "AFAIL"
+	// CodeAuthServiceConnection means the auth service could not be reached.
+	CodeAuthServiceConnection = "ACONN"
 
 	// CodeMethodNotSupported means a request was made against a resource with an unsupported method.
 	CodeMethodNotSupported = "MINVAL"

--- a/context.go
+++ b/context.go
@@ -83,7 +83,7 @@ func NewContext() (*Context, error) {
 		"key":                c.Key,
 		"default layer":      c.Image,
 		"polling interval":   c.Poll,
-		"auth service":       c.AuthService,
+		"auth service":       c.Settings.AuthService,
 	}).Info("Initializing with loaded settings.")
 
 	// Configure a HTTP(S) client to use the provided TLS credentials.

--- a/context.go
+++ b/context.go
@@ -138,13 +138,20 @@ func NewContext() (*Context, error) {
 			log.WithFields(log.Fields{
 				"docker host": c.DockerHost,
 				"error":       err,
-			}).Fatal("Unable to connect to Docker.")
+			}).Error("Unable to connect to Docker.")
 			return c, err
 		}
 	}
 
 	// Initialize an appropriate authentication service.
-	c.AuthService = ConnectToAuthService(c, c.Settings.AuthService)
+	c.AuthService, err = ConnectToAuthService(c, c.Settings.AuthService)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"auth service url": c.Settings.AuthService,
+			"error":            err,
+		}).Error("Unable to connect to authentication service.")
+		return c, err
+	}
 
 	return c, nil
 }

--- a/context.go
+++ b/context.go
@@ -17,11 +17,16 @@ import (
 
 // Context provides shared state among individual route handlers.
 type Context struct {
+	// Configuration settings from the environment.
 	Settings
+
+	// Service facades.
 	Storage
 	Docker
 
-	HTTPS *http.Client
+	// Shared clients.
+	HTTPS       *http.Client
+	AuthService AuthService
 }
 
 // Settings contains configuration options loaded from the environment.
@@ -78,6 +83,7 @@ func NewContext() (*Context, error) {
 		"key":                c.Key,
 		"default layer":      c.Image,
 		"polling interval":   c.Poll,
+		"auth service":       c.AuthService,
 	}).Info("Initializing with loaded settings.")
 
 	// Configure a HTTP(S) client to use the provided TLS credentials.
@@ -136,6 +142,9 @@ func NewContext() (*Context, error) {
 			return c, err
 		}
 	}
+
+	// Initialize an appropriate authentication service.
+	c.AuthService = ConnectToAuthService(c, c.Settings.AuthService)
 
 	return c, nil
 }

--- a/context.go
+++ b/context.go
@@ -20,20 +20,20 @@ type Context struct {
 
 // Settings contains configuration options loaded from the environment.
 type Settings struct {
-	Port         int
-	LogLevel     string
-	LogColors    bool
-	MongoURL     string
-	AdminName    string
-	AdminKey     string
-	DockerHost   string
-	DockerTLS    bool
-	DockerCACert string
-	DockerCert   string
-	DockerKey    string
-	Image        string
-	Poll         int
-	AuthService  string
+	Port        int
+	LogLevel    string
+	LogColors   bool
+	MongoURL    string
+	AdminName   string
+	AdminKey    string
+	DockerHost  string
+	DockerTLS   bool
+	CACert      string
+	Cert        string
+	Key         string
+	Image       string
+	Poll        int
+	AuthService string
 }
 
 // NewContext loads the active configuration and applies any immediate, global settings like the
@@ -67,9 +67,9 @@ func NewContext() (*Context, error) {
 		"admin account":      c.AdminName,
 		"docker host":        c.DockerHost,
 		"docker TLS enabled": c.DockerTLS,
-		"docker CA cert":     c.DockerCACert,
-		"docker cert":        c.DockerCert,
-		"docker key":         c.DockerKey,
+		"CA cert":            c.CACert,
+		"cert":               c.Cert,
+		"key":                c.Key,
 		"default layer":      c.Image,
 		"polling interval":   c.Poll,
 	}).Info("Initializing with loaded settings.")
@@ -87,13 +87,10 @@ func NewContext() (*Context, error) {
 	// Connect to Docker.
 
 	if c.DockerTLS {
-		c.Docker, err = docker.NewTLSClient(c.DockerHost, c.DockerCert, c.DockerKey, c.DockerCACert)
+		c.Docker, err = docker.NewTLSClient(c.DockerHost, c.Cert, c.Key, c.CACert)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"docker host":    c.DockerHost,
-				"docker cert":    c.DockerCert,
-				"docker key":     c.DockerKey,
-				"docker CA cert": c.DockerCACert,
+				"docker host": c.DockerHost,
 			}).Fatal("Unable to connect to Docker with TLS.")
 			return c, err
 		}
@@ -151,16 +148,16 @@ func (c *Context) Load() error {
 		certRoot = path.Join(user.HomeDir, ".docker")
 	}
 
-	if c.DockerCACert == "" {
-		c.DockerCACert = path.Join(certRoot, "ca.pem")
+	if c.CACert == "" {
+		c.CACert = path.Join(certRoot, "ca.pem")
 	}
 
-	if c.DockerCert == "" {
-		c.DockerCert = path.Join(certRoot, "cert.pem")
+	if c.Cert == "" {
+		c.Cert = path.Join(certRoot, "cert.pem")
 	}
 
-	if c.DockerKey == "" {
-		c.DockerKey = path.Join(certRoot, "key.pem")
+	if c.Key == "" {
+		c.Key = path.Join(certRoot, "key.pem")
 	}
 
 	if c.Image == "" {

--- a/context.go
+++ b/context.go
@@ -32,6 +32,7 @@ type Settings struct {
 	DockerKey    string
 	Image        string
 	Poll         int
+	AuthService  string
 }
 
 // NewContext loads the active configuration and applies any immediate, global settings like the

--- a/context.go
+++ b/context.go
@@ -22,6 +22,7 @@ type Context struct {
 type Settings struct {
 	Port         int
 	LogLevel     string
+	LogColors    bool
 	MongoURL     string
 	AdminName    string
 	AdminKey     string
@@ -44,11 +45,24 @@ func NewContext() (*Context, error) {
 		return c, err
 	}
 
+	// Configure the logging level and formatter.
+
+	level, err := log.ParseLevel(c.LogLevel)
+	if err != nil {
+		return c, err
+	}
+	log.SetLevel(level)
+
+	log.SetFormatter(&log.TextFormatter{
+		ForceColors: c.LogColors,
+	})
+
 	// Summarize the loaded settings.
 
 	log.WithFields(log.Fields{
 		"port":               c.Port,
 		"logging level":      c.LogLevel,
+		"log with color":     c.LogColors,
 		"mongo URL":          c.MongoURL,
 		"admin account":      c.AdminName,
 		"docker host":        c.DockerHost,
@@ -59,14 +73,6 @@ func NewContext() (*Context, error) {
 		"default layer":      c.Image,
 		"polling interval":   c.Poll,
 	}).Info("Initializing with loaded settings.")
-
-	// Configure the logging level.
-
-	level, err := log.ParseLevel(c.LogLevel)
-	if err != nil {
-		return c, err
-	}
-	log.SetLevel(level)
 
 	// Connect to MongoDB.
 

--- a/context_test.go
+++ b/context_test.go
@@ -22,6 +22,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 	os.Setenv("PIPE_DOCKERCACERT", "/lockbox/ca.pem")
 	os.Setenv("PIPE_DOCKERCERT", "/lockbox/cert.pem")
 	os.Setenv("PIPE_DOCKERKEY", "/lockbox/key.pem")
+	os.Setenv("PIPE_AUTHSERVICE", "https://auth")
 
 	if err := c.Load(); err != nil {
 		t.Errorf("Error loading configuration: %v", err)
@@ -74,6 +75,10 @@ func TestLoadFromEnvironment(t *testing.T) {
 	if c.AdminKey != "12345" {
 		t.Errorf("Unexpected administrator API key: [%s]", c.AdminKey)
 	}
+
+	if c.AuthService != "https://auth" {
+		t.Errorf("Unexpected authentication service URL: [%s]", c.AuthService)
+	}
 }
 
 func TestDefaultValues(t *testing.T) {
@@ -94,6 +99,7 @@ func TestDefaultValues(t *testing.T) {
 	os.Setenv("DOCKER_TLS_VERIFY", "")
 	os.Setenv("DOCKER_CERT_PATH", "")
 	os.Setenv("PIPE_IMAGE", "")
+	os.Setenv("PIPE_AUTHSERVICE", "")
 
 	u, err := user.Current()
 	if err != nil {
@@ -143,6 +149,10 @@ func TestDefaultValues(t *testing.T) {
 
 	if c.Image != "cloudpipe/runner-py2" {
 		t.Errorf("Unexpected default image: [%s]", c.Image)
+	}
+
+	if c.AuthService != "" {
+		t.Errorf("Unexpected default auth service: [%s]", c.AuthService)
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -81,7 +81,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 		t.Errorf("Unexpected administrator API key: [%s]", c.AdminKey)
 	}
 
-	if c.AuthService != "https://auth" {
+	if c.Settings.AuthService != "https://auth" {
 		t.Errorf("Unexpected authentication service URL: [%s]", c.AuthService)
 	}
 }
@@ -161,7 +161,7 @@ func TestDefaultValues(t *testing.T) {
 		t.Errorf("Unexpected default image: [%s]", c.Image)
 	}
 
-	if c.AuthService != "" {
+	if c.Settings.AuthService != "" {
 		t.Errorf("Unexpected default auth service: [%s]", c.AuthService)
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -20,9 +20,9 @@ func TestLoadFromEnvironment(t *testing.T) {
 	os.Setenv("PIPE_IMAGE", "cloudpipe/runner-py2")
 	os.Setenv("PIPE_DOCKERHOST", "tcp://1.2.3.4:4567/")
 	os.Setenv("PIPE_DOCKERTLS", "true")
-	os.Setenv("PIPE_DOCKERCACERT", "/lockbox/ca.pem")
-	os.Setenv("PIPE_DOCKERCERT", "/lockbox/cert.pem")
-	os.Setenv("PIPE_DOCKERKEY", "/lockbox/key.pem")
+	os.Setenv("PIPE_CACERT", "/lockbox/ca.pem")
+	os.Setenv("PIPE_CERT", "/lockbox/cert.pem")
+	os.Setenv("PIPE_KEY", "/lockbox/key.pem")
 	os.Setenv("PIPE_AUTHSERVICE", "https://auth")
 
 	if err := c.Load(); err != nil {
@@ -57,16 +57,16 @@ func TestLoadFromEnvironment(t *testing.T) {
 		t.Errorf("Expected docker TLS to be enabled.")
 	}
 
-	if c.DockerCACert != "/lockbox/ca.pem" {
-		t.Errorf("Unexpected docker CA cert: [%s]", c.DockerCACert)
+	if c.CACert != "/lockbox/ca.pem" {
+		t.Errorf("Unexpected docker CA cert: [%s]", c.CACert)
 	}
 
-	if c.DockerCert != "/lockbox/cert.pem" {
-		t.Errorf("Unexpected docker cert: [%s]", c.DockerCert)
+	if c.Cert != "/lockbox/cert.pem" {
+		t.Errorf("Unexpected docker cert: [%s]", c.Cert)
 	}
 
-	if c.DockerKey != "/lockbox/key.pem" {
-		t.Errorf("Unexpected docker key: [%s]", c.DockerKey)
+	if c.Key != "/lockbox/key.pem" {
+		t.Errorf("Unexpected docker key: [%s]", c.Key)
 	}
 
 	if c.Image != "cloudpipe/runner-py2" {
@@ -99,9 +99,9 @@ func TestDefaultValues(t *testing.T) {
 	os.Setenv("PIPE_DOCKERHOST", "")
 	os.Setenv("DOCKER_HOST", "")
 	os.Setenv("PIPE_DOCKERTLS", "")
-	os.Setenv("PIPE_DOCKERCACERT", "")
-	os.Setenv("PIPE_DOCKERCERT", "")
-	os.Setenv("PIPE_DOCKERKEY", "")
+	os.Setenv("PIPE_CACERT", "")
+	os.Setenv("PIPE_CERT", "")
+	os.Setenv("PIPE_KEY", "")
 	os.Setenv("DOCKER_TLS_VERIFY", "")
 	os.Setenv("DOCKER_CERT_PATH", "")
 	os.Setenv("PIPE_IMAGE", "")
@@ -145,16 +145,16 @@ func TestDefaultValues(t *testing.T) {
 		t.Errorf("Expected docker TLS to be disabled.")
 	}
 
-	if c.DockerCACert != path.Join(home, ".docker", "ca.pem") {
-		t.Errorf("Unexpected docker CA cert: [%s]", c.DockerCACert)
+	if c.CACert != path.Join(home, ".docker", "ca.pem") {
+		t.Errorf("Unexpected docker CA cert: [%s]", c.CACert)
 	}
 
-	if c.DockerCert != path.Join(home, ".docker", "cert.pem") {
-		t.Errorf("Unexpected docker cert: [%s]", c.DockerCert)
+	if c.Cert != path.Join(home, ".docker", "cert.pem") {
+		t.Errorf("Unexpected docker cert: [%s]", c.Cert)
 	}
 
-	if c.DockerKey != path.Join(home, ".docker", "key.pem") {
-		t.Errorf("Unexpected docker key: [%s]", c.DockerKey)
+	if c.Key != path.Join(home, ".docker", "key.pem") {
+		t.Errorf("Unexpected docker key: [%s]", c.Key)
 	}
 
 	if c.Image != "cloudpipe/runner-py2" {

--- a/context_test.go
+++ b/context_test.go
@@ -12,6 +12,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 
 	os.Setenv("PIPE_PORT", "1234")
 	os.Setenv("PIPE_LOGLEVEL", "debug")
+	os.Setenv("PIPE_LOGCOLORS", "true")
 	os.Setenv("PIPE_MONGOURL", "server.example.com")
 	os.Setenv("PIPE_ADMINNAME", "fake")
 	os.Setenv("PIPE_ADMINKEY", "12345")
@@ -34,6 +35,10 @@ func TestLoadFromEnvironment(t *testing.T) {
 
 	if c.LogLevel != "debug" {
 		t.Errorf("Unexpected log level: [%s]", c.LogLevel)
+	}
+
+	if !c.LogColors {
+		t.Error("Expected log coloring to be enabled")
 	}
 
 	if c.MongoURL != "server.example.com" {
@@ -86,6 +91,7 @@ func TestDefaultValues(t *testing.T) {
 
 	os.Setenv("PIPE_PORT", "")
 	os.Setenv("PIPE_LOGLEVEL", "")
+	os.Setenv("PIPE_LOGCOLORS", "")
 	os.Setenv("PIPE_MONGOURL", "")
 	os.Setenv("PIPE_ADMINNAME", "")
 	os.Setenv("PIPE_ADMINKEY", "")
@@ -117,6 +123,10 @@ func TestDefaultValues(t *testing.T) {
 
 	if c.LogLevel != "info" {
 		t.Errorf("Unexpected logging level: [%s]", c.LogLevel)
+	}
+
+	if c.LogColors {
+		t.Error("Expected logging colors to be disabled by default")
 	}
 
 	if c.MongoURL != "mongo" {

--- a/fig.yml
+++ b/fig.yml
@@ -8,6 +8,9 @@ cloudpipe:
     PIPE_ADMINKEY: 12345
     PIPE_LOGLEVEL: debug
     PIPE_LOGCOLORS: true
+    PIPE_CACERT: ${PWD}/certificates/ca.pem
+    PIPE_CERT: ${PWD}/certificates/cloudpipe-cert.pem
+    PIPE_KEY: ${PWD}/certificates/cloudpipe-key.pem
   ports:
   - "8000:8000"
   volumes:

--- a/fig.yml
+++ b/fig.yml
@@ -8,13 +8,14 @@ cloudpipe:
     PIPE_ADMINKEY: 12345
     PIPE_LOGLEVEL: debug
     PIPE_LOGCOLORS: true
-    PIPE_CACERT: ${PWD}/certificates/ca.pem
-    PIPE_CERT: ${PWD}/certificates/cloudpipe-cert.pem
-    PIPE_KEY: ${PWD}/certificates/cloudpipe-key.pem
+    PIPE_CACERT: /certificates/ca.pem
+    PIPE_CERT: /certificates/cloudpipe-cert.pem
+    PIPE_KEY: /certificates/cloudpipe-key.pem
   ports:
   - "8000:8000"
   volumes:
   - "/var/run/docker.sock:/var/run/docker.sock"
+  - "certificates:/certificates"
 mongo:
   image: mongo:2.8
 dummyuserimage:

--- a/fig.yml
+++ b/fig.yml
@@ -3,6 +3,7 @@ cloudpipe:
   build: .
   links:
   - mongo
+  - authstore
   environment:
     PIPE_ADMINNAME: admin
     PIPE_ADMINKEY: 12345
@@ -11,10 +12,25 @@ cloudpipe:
     PIPE_CACERT: /certificates/ca.pem
     PIPE_CERT: /certificates/cloudpipe-cert.pem
     PIPE_KEY: /certificates/cloudpipe-key.pem
+    PIPE_AUTHSERVICE: https://authstore:8000/v1
   ports:
   - "8000:8000"
   volumes:
   - "/var/run/docker.sock:/var/run/docker.sock"
+  - "certificates:/certificates"
+authstore:
+  image: cloudpipe/auth-store
+  links:
+  - mongo
+  environment:
+    AUTH_LOGLEVEL: debug
+    AUTH_LOGCOLORS: true
+    AUTH_CACERT: /certificates/ca.pem
+    AUTH_CERT: /certificates/auth-store-cert.pem
+    AUTH_KEY: /certificates/auth-store-key.pem
+  ports:
+  - "8001:8000"
+  volumes:
   - "certificates:/certificates"
 mongo:
   image: mongo:2.8

--- a/fig.yml
+++ b/fig.yml
@@ -7,6 +7,7 @@ cloudpipe:
     PIPE_ADMINNAME: admin
     PIPE_ADMINKEY: 12345
     PIPE_LOGLEVEL: debug
+    PIPE_LOGCOLORS: true
   ports:
   - "8000:8000"
   volumes:

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ func main() {
 	go Runner(c)
 
 	// v1 routes
+	http.HandleFunc("/v1/auth_service", BindContext(c, AuthDiscoverHandler))
+
 	http.HandleFunc("/v1/job", BindContext(c, JobHandler))
 	http.HandleFunc("/v1/job/kill", BindContext(c, JobKillHandler))
 	http.HandleFunc("/v1/job/kill_all", BindContext(c, JobKillAllHandler))

--- a/script/genkeys
+++ b/script/genkeys
@@ -80,6 +80,12 @@ keypair() {
     ${EXTOPT} \
     -out /certificates/${NAME}-cert.pem
 
+  echo ".. removing key password"
+  ${OPENSSL} openssl rsa \
+    -passin ${PASSOPT} \
+    -in /certificates/${NAME}-key.pem \
+    -out /certificates/${NAME}-key.pem
+
   echo "<< ${NAME} keypair generated."
 }
 

--- a/script/genkeys
+++ b/script/genkeys
@@ -10,12 +10,31 @@ OPENSSL="docker run --interactive=true --tty=true"
 OPENSSL="${OPENSSL} --volume ${ROOT}/certificates:/certificates --rm smashwilson/openssl"
 
 FIRSTCERT="true"
+PASSFILE="${ROOT}/certificates/dev.password"
+PASSOPT="file:/certificates/dev.password"
+
+# Randomly create a password file, if you haven't supplied one already.
+# For development mode, we'll just use the same (random) password for everything.
+if [ ! -f "${PASSFILE}" ]; then
+  echo ">> creating a random password in ${PASSFILE}."
+  touch ${PASSFILE}
+  chmod 600 ${PASSFILE}
+  # "If the same pathname argument is supplied to -passin and -passout arguments then the first
+  # line will be used for the input password and the next line for the output password."
+  cat /dev/random | head -c 128 | base64 | sed -n '{p;p;}' >> ${PASSFILE}
+  echo "<< random password created"
+fi
 
 # Generate the certificate authority that we'll use as the root for all the things.
 echo ">> generating a certificate authority"
-${OPENSSL} openssl genrsa -des3 -out /certificates/ca-key.pem 2048
+${OPENSSL} openssl genrsa -des3 \
+  -passout ${PASSOPT} \
+  -out /certificates/ca-key.pem 2048
 ${OPENSSL} openssl req -new -x509 -days 365 \
+  -batch \
+  -passin ${PASSOPT} \
   -key /certificates/ca-key.pem \
+  -passout ${PASSOPT} \
   -out /certificates/ca.pem
 echo "<< certificate authority generated."
 
@@ -33,15 +52,21 @@ keypair() {
   echo ">> generating a keypair for: ${NAME}"
 
   echo ".. key"
-  ${OPENSSL} openssl genrsa -des3 -out /certificates/${NAME}-key.pem 2048
+  ${OPENSSL} openssl genrsa -des3 \
+    -passout ${PASSOPT} \
+    -out /certificates/${NAME}-key.pem 2048
 
   echo ".. request"
   ${OPENSSL} openssl req -subj "/CN=${HOSTNAME}" -new \
+    -batch \
+    -passin ${PASSOPT} \
     -key /certificates/${NAME}-key.pem \
+    -passout ${PASSOPT} \
     -out /certificates/${NAME}-req.csr
 
   echo ".. certificate"
   ${OPENSSL} openssl x509 -req -days 365 \
+    -passin ${PASSOPT} \
     -in /certificates/${NAME}-req.csr \
     -CA /certificates/ca.pem \
     -CAkey /certificates/ca-key.pem \

--- a/script/genkeys
+++ b/script/genkeys
@@ -6,8 +6,7 @@ set -o errexit
 
 ROOT=$(cd $(dirname $0)/..; pwd)
 
-OPENSSL="docker run --interactive=true --tty=true"
-OPENSSL="${OPENSSL} --volume ${ROOT}/certificates:/certificates --rm smashwilson/openssl"
+OPENSSL="docker run --volume ${ROOT}/certificates:/certificates --rm smashwilson/openssl"
 
 FIRSTCERT="true"
 PASSFILE="${ROOT}/certificates/dev.password"

--- a/script/genkeys
+++ b/script/genkeys
@@ -41,11 +41,18 @@ echo "<< certificate authority generated."
 keypair() {
   local NAME=$1
   local HOSTNAME=$2
+  local CLIENT=$3
+
   local SERIALOPT="-CAserial /certificates/ca.srl"
+  local EXTOPT=""
 
   if [ "${FIRSTCERT}" = "true" ]; then
     SERIALOPT="-CAcreateserial"
     FIRSTCERT="false"
+  fi
+
+  if [ "${CLIENT}" = "true" ]; then
+    EXTOPT="-extfile /certificates/extclient.cnf"
   fi
 
   echo ">> generating a keypair for: ${NAME}"
@@ -70,13 +77,14 @@ keypair() {
     -CA /certificates/ca.pem \
     -CAkey /certificates/ca-key.pem \
     ${SERIALOPT} \
+    ${EXTOPT} \
     -out /certificates/${NAME}-cert.pem
 
   echo "<< ${NAME} keypair generated."
 }
 
 # Keypair for the API and job runner.
-keypair cloudpipe cloudpipe
+keypair cloudpipe cloudpipe "true"
 
 # Keypair for the authentication server.
-keypair auth-local auth
+keypair auth-local auth "false"

--- a/script/genkeys
+++ b/script/genkeys
@@ -93,4 +93,4 @@ keypair() {
 keypair cloudpipe cloudpipe "true"
 
 # Keypair for the authentication server.
-keypair auth-store auth "false"
+keypair auth-store authstore "false"

--- a/script/genkeys
+++ b/script/genkeys
@@ -93,4 +93,4 @@ keypair() {
 keypair cloudpipe cloudpipe "true"
 
 # Keypair for the authentication server.
-keypair auth-local auth "false"
+keypair auth-store auth "false"

--- a/script/genkeys
+++ b/script/genkeys
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Generate a set of TLS credentials that can be used to run development mode.
+
+set -o errexit
+
+ROOT=$(cd $(dirname $0)/..; pwd)
+
+OPENSSL="docker run --interactive=true --tty=true"
+OPENSSL="${OPENSSL} --volume ${ROOT}/certificates:/certificates --rm smashwilson/openssl"
+
+FIRSTCERT="true"
+
+# Generate the certificate authority that we'll use as the root for all the things.
+echo ">> generating a certificate authority"
+${OPENSSL} openssl genrsa -des3 -out /certificates/ca-key.pem 2048
+${OPENSSL} openssl req -new -x509 -days 365 \
+  -key /certificates/ca-key.pem \
+  -out /certificates/ca.pem
+echo "<< certificate authority generated."
+
+# Generate a named keypair
+keypair() {
+  local NAME=$1
+  local HOSTNAME=$2
+  local SERIALOPT="-CAserial /certificates/ca.srl"
+
+  if [ "${FIRSTCERT}" = "true" ]; then
+    SERIALOPT="-CAcreateserial"
+    FIRSTCERT="false"
+  fi
+
+  echo ">> generating a keypair for: ${NAME}"
+
+  echo ".. key"
+  ${OPENSSL} openssl genrsa -des3 -out /certificates/${NAME}-key.pem 2048
+
+  echo ".. request"
+  ${OPENSSL} openssl req -subj "/CN=${HOSTNAME}" -new \
+    -key /certificates/${NAME}-key.pem \
+    -out /certificates/${NAME}-req.csr
+
+  echo ".. certificate"
+  ${OPENSSL} openssl x509 -req -days 365 \
+    -in /certificates/${NAME}-req.csr \
+    -CA /certificates/ca.pem \
+    -CAkey /certificates/ca-key.pem \
+    ${SERIALOPT} \
+    -out /certificates/${NAME}-cert.pem
+
+  echo "<< ${NAME} keypair generated."
+}
+
+# Keypair for the API and job runner.
+keypair cloudpipe cloudpipe
+
+# Keypair for the authentication server.
+keypair auth-local auth

--- a/script/test
+++ b/script/test
@@ -1,17 +1,10 @@
 #!/bin/bash
 
+set -e
+
 ROOT=$(dirname $0)/..
 cd ${ROOT}
 
-fig build
+fig build >/dev/null 2>&1 || echo "fig build failed!"
 
-echo ">> cloudpipe tests"
-
-fig run --rm cloudpipe go test github.com/cloudpipe/cloudpipe/...
-STATUS=$?
-
-if [ "${STATUS}" != "0" ]; then
-  echo "!! cloudpipe tests are failing"
-else
-  echo "<< cloudpipe tests passed"
-fi
+exec fig run --no-deps --rm cloudpipe go test github.com/cloudpipe/cloudpipe/... $@


### PR DESCRIPTION
I'm creating a mechanism to provide pluggable authentication services. Go doesn't allow dynamic linking, so I'm going to call out to another daemon over https with a [custom TLS root CA certificate](http://stackoverflow.com/questions/21562269/golang-how-to-specify-certificate-in-tls-config-for-http-client) (probably using the same CA certificate that the Docker daemon does). I'm outlining the protocol for this [on the wiki](https://github.com/cloudpipe/cloudpipe/wiki/Authentication).