### PR TITLE
Update auth-store connection

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/user"
 	"path"
 
 	log "github.com/Sirupsen/logrus"
@@ -188,12 +187,7 @@ func (c *Context) Load() error {
 
 	certRoot := os.Getenv("DOCKER_CERT_PATH")
 	if certRoot == "" {
-		user, err := user.Current()
-		if err != nil {
-			return fmt.Errorf("Unable to read the current OS user: %v", err)
-		}
-
-		certRoot = path.Join(user.HomeDir, ".docker")
+		certRoot = "/certificates"
 	}
 
 	if c.CACert == "" {
@@ -201,15 +195,19 @@ func (c *Context) Load() error {
 	}
 
 	if c.Cert == "" {
-		c.Cert = path.Join(certRoot, "cert.pem")
+		c.Cert = path.Join(certRoot, "cloudpipe-cert.pem")
 	}
 
 	if c.Key == "" {
-		c.Key = path.Join(certRoot, "key.pem")
+		c.Key = path.Join(certRoot, "cloudpipe-key.pem")
 	}
 
 	if c.Image == "" {
 		c.Image = "cloudpipe/runner-py2"
+	}
+
+	if c.Settings.AuthService == "" {
+		c.Settings.AuthService = "https://authstore:9001/v1"
 	}
 
 	if _, err := log.ParseLevel(c.LogLevel); err != nil {

--- a/context_test.go
+++ b/context_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"os"
-	"os/user"
-	"path"
 	"testing"
 )
 
@@ -107,12 +105,6 @@ func TestDefaultValues(t *testing.T) {
 	os.Setenv("PIPE_IMAGE", "")
 	os.Setenv("PIPE_AUTHSERVICE", "")
 
-	u, err := user.Current()
-	if err != nil {
-		t.Errorf("Unable to identify current user: %v", err)
-	}
-	home := u.HomeDir
-
 	if err := c.Load(); err != nil {
 		t.Errorf("Error loading configuration: %v", err)
 	}
@@ -145,15 +137,15 @@ func TestDefaultValues(t *testing.T) {
 		t.Errorf("Expected docker TLS to be disabled.")
 	}
 
-	if c.CACert != path.Join(home, ".docker", "ca.pem") {
+	if c.CACert != "/certificates/ca.pem" {
 		t.Errorf("Unexpected docker CA cert: [%s]", c.CACert)
 	}
 
-	if c.Cert != path.Join(home, ".docker", "cert.pem") {
+	if c.Cert != "/certificates/cloudpipe-cert.pem" {
 		t.Errorf("Unexpected docker cert: [%s]", c.Cert)
 	}
 
-	if c.Key != path.Join(home, ".docker", "key.pem") {
+	if c.Key != "/certificates/cloudpipe-key.pem" {
 		t.Errorf("Unexpected docker key: [%s]", c.Key)
 	}
 
@@ -161,7 +153,7 @@ func TestDefaultValues(t *testing.T) {
 		t.Errorf("Unexpected default image: [%s]", c.Image)
 	}
 
-	if c.Settings.AuthService != "" {
+	if c.Settings.AuthService != "https://authstore:9001/v1" {
 		t.Errorf("Unexpected default auth service: [%s]", c.AuthService)
 	}
 }

--- a/fig.yml
+++ b/fig.yml
@@ -12,7 +12,7 @@ cloudpipe:
     PIPE_CACERT: /certificates/ca.pem
     PIPE_CERT: /certificates/cloudpipe-cert.pem
     PIPE_KEY: /certificates/cloudpipe-key.pem
-    PIPE_AUTHSERVICE: https://authstore:8000/v1
+    PIPE_AUTHSERVICE: https://authstore:9001/v1
   ports:
   - "8000:8000"
   volumes:

--- a/fig.yml
+++ b/fig.yml
@@ -25,11 +25,15 @@ authstore:
   environment:
     AUTH_LOGLEVEL: debug
     AUTH_LOGCOLORS: true
-    AUTH_CACERT: /certificates/ca.pem
-    AUTH_CERT: /certificates/auth-store-cert.pem
-    AUTH_KEY: /certificates/auth-store-key.pem
+    AUTH_INTERNALCACERT: /certificates/ca.pem
+    AUTH_INTERNALCERT: /certificates/auth-store-cert.pem
+    AUTH_INTERNALKEY: /certificates/auth-store-key.pem
+    AUTH_EXTERNALCERT: /certificates/external-cert.pem
+    AUTH_EXTERNALKEY: /certificates/external-key.pem
+  expose:
+  - "9001"
   ports:
-  - "8001:8000"
+  - "9000:9000"
   volumes:
   - "certificates:/certificates"
 mongo:

--- a/script/genkeys
+++ b/script/genkeys
@@ -37,7 +37,8 @@ ${OPENSSL} openssl req -new -x509 -days 365 \
   -out /certificates/ca.pem
 echo "<< certificate authority generated."
 
-# Generate a named keypair
+# Generate a named keypair that's signed by the certificate authority. These should be used for
+# internal communications.
 keypair() {
   local NAME=$1
   local HOSTNAME=$2
@@ -89,8 +90,23 @@ keypair() {
   echo "<< ${NAME} keypair generated."
 }
 
+# Generate an independent, self-signed keypair that isn't related to the certificate authority, to
+# be used for externally facing SSL endpoints.
+selfsigned() {
+  local NAME=$1
+
+  echo ">> generating keypair for ${NAME}"
+  ${OPENSSL} openssl req -x509 -newkey rsa:2048 -days 365 -nodes -batch \
+    -keyout /certificates/${NAME}-key.pem \
+    -out /certificates/${NAME}-cert.pem
+  echo "<< keypair generated for ${NAME}"
+}
+
 # Keypair for the API and job runner.
 keypair cloudpipe cloudpipe "true"
 
 # Keypair for the authentication server.
 keypair auth-store authstore "false"
+
+# Self-signed, independent keypair to be used by externally accessible endpoints.
+selfsigned external


### PR DESCRIPTION
Now that we have a [real auth service](https://github.com/cloudpipe/auth-store) to test against, it would be good to default the configuration setting to actually point to it by default.

Also, certificate paths should default to the paths that I use *inside* the container.