### PR TITLE
Target mongo:2.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ authstore:
   volumes:
   - "certificates:/certificates"
 mongo:
-  image: mongo:2.8
+  image: mongo:2.6
 dummyuserimage:
   image: cloudpipe/runner-py2
   command: "echo 'User image loaded'"


### PR DESCRIPTION
On a side note, 2.8 doesn't actually exist anymore. "MongoDB changed from 2.8.x and called it 3.0.x instead"