### PR TITLE
connect to objectrocket over ssl

### DIFF
--- a/context.go
+++ b/context.go
@@ -30,20 +30,23 @@ type Context struct {
 
 // Settings contains configuration options loaded from the environment.
 type Settings struct {
-	Port         int
-	LogLevel     string
-	LogColors    bool
-	MongoURL     string
-	AdminName    string
-	AdminKey     string
-	DockerHost   string
-	DockerTLS    bool
-	CACert       string
-	Cert         string
-	Key          string
-	DefaultImage string
-	Poll         int
-	AuthService  string
+	Port          int
+	LogLevel      string
+	LogColors     bool
+	MongoURL      string
+	MongoDB       string
+	MongoUser     string
+	MongoPassword string
+	AdminName     string
+	AdminKey      string
+	DockerHost    string
+	DockerTLS     bool
+	CACert        string
+	Cert          string
+	Key           string
+	DefaultImage  string
+	Poll          int
+	AuthService   string
 }
 
 // NewContext loads the active configuration and applies any immediate, global settings like the


### PR DESCRIPTION
This PR creates an SSL connection by default. One thing to note is that, as is, 3 new config variables will need to be added to the `docker-compose.yml` file in the `cloudpipe-rackspace-auth-store` repo. (Namely, MONGODB, MONGOUSER, and MONGOPASSWORD).