### PR TITLE
Use the cloudpipe mgo fork, based on mgov2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -52,6 +52,10 @@
 			"Rev": "ddb122d10f547ee6cfc4ea7debff407d80abdabc"
 		},
 		{
+				"ImportPath": "github.com/cloudpipe/mgo",
+				"Rev": "4791883005793404c4d2775c85f9466e51597969"
+		},
+		{
 			"ImportPath": "gopkg.in/mgo.v2",
 			"Rev": "e2e914857713db7497cca2bd7fc0b030fc9cb22d"
 		}

--- a/storage.go
+++ b/storage.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
+	mgo "github.com/cloudpipe/mgo"
+	"github.com/cloudpipe/mgo/bson"
 
 	log "github.com/Sirupsen/logrus"
 )


### PR DESCRIPTION
Just like https://github.com/jrperritt/cloudpipe/pull/1, uses a fork of mgo to handle SSL directly.

This way, proper URLs to pass cloudpipe can e.g. be:

### Plaintext
```
mongodb://user:pass@iad-mongos2.objectrocket.com:10000/pipe
```

### TLS/SSL
```
mongodb://user:pass@iad-mongos2.objectrocket.com:20000/pipe?ssl=true
```

while handling all the other options that mgo handles. I'll continue to try getting a better option for upstream considering the opposition faced in https://github.com/go-mgo/mgo/pull/86.