### PR TITLE
Expose 8000 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN useradd pipe && \
   chown -R pipe:pipe /go
 
 # USER pipe
+EXPOSE 8000
 
 ADD ./Godeps /go/src/github.com/cloudpipe/cloudpipe/Godeps
 WORKDIR /go/src/github.com/cloudpipe/cloudpipe/


### PR DESCRIPTION
Through some strangeness, we found out that with Ansible 1.9 even if you map the ports:

```yaml
    ports:
      - "8000:8000"
```

It doesn't automatically expose them. The Docker CLI does this as does docker compose. Ended up having to add this to the playbook:

```yaml
    expose:
      - "8000"
    ports:
      - "8000:8000"
```

We should probably file an upstream bug/patch too.

Thank you to @jhamrick and @smashwilson for helping me frantically debug a deployment.